### PR TITLE
Ignoring jars in folder Performer/fey/FeyJarRepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ metastore_db/
 
 #nohup files
 nohup*.out
+
+#generated jars
+Performers/fey/FeyJARRepo/*.jar


### PR DESCRIPTION
Jars should not be available in the repo. Each developer/user should build its own.