### PR TITLE
Implementing Monitor actor on Fey

### DIFF
--- a/fey-core/src/main/resources/eventsTable.html
+++ b/fey-core/src/main/resources/eventsTable.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+table {
+    font-family: arial, sans-serif;
+    border-collapse: collapse;
+    width: 100%;
+}
+
+td, th {
+    border: 1px solid #dddddd;
+    text-align: left;
+    padding: 8px;
+}
+
+tr:nth-child(even) {
+    background-color: #dddddd;
+}
+</style>
+</head>
+<body>
+
+<table>
+    <tr>
+        <th>GUID</th>
+        <th>Event</th>
+        <th>Info</th>
+        <th>Timestamp</th>
+    </tr>
+    $EVENTS_TABLE_CONTENT
+</table>
+
+</body>
+</html>

--- a/fey-core/src/main/resources/logback.xml
+++ b/fey-core/src/main/resources/logback.xml
@@ -18,83 +18,47 @@
 
 <configuration>
 
+    <property name="LOG_HOME" value="${HOME}/.fey/logs" />
+
     <appender name="FEY-CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.out</target>
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>[%p] [%d{yy/MM/dd HH:mm:ss}] %c [%X{akkaSource}]: %msg%n</pattern>
+            <pattern>[%p] [%d{yy/MM/dd HH:mm:ss}] %c [%X{akkaSource}] : %msg%n</pattern>
         </encoder>
     </appender>
 
-    <!-- Fey core -->
-    <appender name="FEY-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <append>true</append>
-        <file>${HOME}/.fey/logs/fey_core.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <!-- daily rollover. Make sure the path matches the one in the file element or else
-             the rollover logs are placed in the working directory. -->
-            <fileNamePattern>${HOME}/.fey/logs/fey_core-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>1MB</maxFileSize>
-            <maxHistory>30</maxHistory>
-            <totalSizeCap>1GB</totalSizeCap>
-        </rollingPolicy>
+    <appender name="FEY-FILE" class="ch.qos.logback.classic.sift.SiftingAppender">
 
-       <!-- <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-            <evaluator>
-                <expression>
-                    if(logger.startsWith("com.apache.iota.fey.FeyCore"))
-                        return true;
-                    return false;
-                </expression>
-            </evaluator>
-            <OnMismatch>DENY</OnMismatch>
-            <OnMatch>NEUTRAL</OnMatch>
-        </filter> -->
+        <!-- MDC value -->
+        <discriminator>
+            <key>fileName</key>
+            <defaultValue>fey_core</defaultValue>
+        </discriminator>
 
-        <encoder>
-            <charset>UTF-8</charset>
-            <pattern>[%p] [%d{yy/MM/dd HH:mm:ss}] %c [%X{akkaSource}]: %msg%n</pattern>
-        </encoder>
+        <sift>
+            <!-- Fey core -->
+            <appender name="FEY-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                <append>true</append>
+                <file>${LOG_HOME}/${fileName}.log</file>
+                <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                    <!-- daily rollover. Make sure the path matches the one in the file element or else
+                     the rollover logs are placed in the working directory. -->
+                    <fileNamePattern>${LOG_HOME}/${fileName}-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                    <maxFileSize>1MB</maxFileSize>
+                    <maxHistory>30</maxHistory>
+                    <totalSizeCap>1GB</totalSizeCap>
+                </rollingPolicy>
+
+                <encoder>
+                    <charset>UTF-8</charset>
+                    <pattern>[%p] [%d{yy/MM/dd HH:mm:ss}] %c [%X{akkaSource}] : %msg%n</pattern>
+                </encoder>
+            </appender>
+
+        </sift>
+
     </appender>
-
-    <!-- Orchestrations core -->
-    <!-- <appender name="FILE-ORHC" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <append>true</append>
-        <file>logs/fey_orchestrations.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/fey_orchestrations-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>100KB</maxFileSize>
-            <maxHistory>60</maxHistory>
-            <totalSizeCap>1GB</totalSizeCap>
-        </rollingPolicy>
-
-        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-            <evaluator>
-                <expression>
-                    if(logger.startsWith("com.apache.iota.fey.Orchestration"))
-                    return true;
-                    return false;
-                </expression>
-            </evaluator>
-            <OnMismatch>DENY</OnMismatch>
-            <OnMatch>NEUTRAL</OnMatch>
-        </filter>
-
-        <encoder>
-            <charset>UTF-8</charset>
-            <pattern>[%p] [%d{yy/MM/dd HH:mm:ss}] [%X{akkaSource}]: %msg%n</pattern>
-        </encoder>
-    </appender> -->
-
-    <!-- Logging asynchronously -->
-    <!-- <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
-        <queueSize>1000</queueSize>
-        <appender-ref ref="FILE" />
-    </appender> -->
-
-    <!--
-    <logger name="com.apache.iota.fey" level="INFO" appender="FILE-FEY-CORE"/>
-    <logger name="com.apache.iota.fey.Orchestration" level="INFO" appender="FILE-ORHC"/> -->
 
     <root level="INFO">
         <appender-ref ref="FEY-FILE"/>

--- a/fey-core/src/main/scala/org/apache/iota/fey/Application.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/Application.scala
@@ -30,13 +30,22 @@ object Application extends App {
 
   CONFIG.loadUserConfiguration(if(args.length == 1) args(0) else "")
 
+  SYSTEM_ACTORS
+
+}
+
+object SYSTEM_ACTORS{
+
   implicit val system = ActorSystem("FEY-MANAGEMENT-SYSTEM")
 
   val fey = system.actorOf(FeyCore.props, name = "FEY-CORE")
 
   val service = system.actorOf(Props[MyServiceActor], name = "FEY_REST_API")
 
+  val monitoring = system.actorOf(Props[Monitor], "FEY-MONITOR")
+
   implicit val timeout = Timeout(800.seconds)
-  IO(Http) ? Http.Bind(service, interface = "0.0.0.0", port = 16666)
+  IO(Http) ? Http.Bind(SYSTEM_ACTORS.service, interface = "0.0.0.0", port = 16666)
+
 
 }

--- a/fey-core/src/main/scala/org/apache/iota/fey/DirWatcher.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/DirWatcher.scala
@@ -69,12 +69,19 @@ class DirectoryWatcherActor(val fileExtension: String) extends Actor with ActorL
   var watchThread = new Thread(watchFileTask, "WatchService")
 
   override def preStart() {
+    SYSTEM_ACTORS.monitoring  ! Monitor.START(Utils.getTimestamp)
     watchThread.setDaemon(true)
     watchThread.start()
   }
 
   override def postStop() {
+    SYSTEM_ACTORS.monitoring  ! Monitor.STOP(Utils.getTimestamp)
     watchThread.interrupt()
+  }
+
+  override def postRestart(reason: Throwable): Unit = {
+    SYSTEM_ACTORS.monitoring  ! Monitor.RESTART(reason, Utils.getTimestamp)
+    preStart()
   }
 
   override def receive: Receive = {

--- a/fey-core/src/main/scala/org/apache/iota/fey/FeyGenericActor.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/FeyGenericActor.scala
@@ -82,17 +82,20 @@ abstract class FeyGenericActor(val params: Map[String,String] = Map.empty,
   }
 
   override final def preStart() = {
+    SYSTEM_ACTORS.monitoring  ! Monitor.START(Utils.getTimestamp)
     onStart()
     startScheduler()
   }
 
   override final def postStop() = {
+    SYSTEM_ACTORS.monitoring  ! Monitor.STOP(Utils.getTimestamp)
     log.info(s"STOPPED actor ${self.path.name}")
     stopScheduler()
     onStop()
   }
 
   override final def postRestart(reason: Throwable) = {
+    SYSTEM_ACTORS.monitoring  ! Monitor.RESTART(reason, Utils.getTimestamp)
     log.info(s"RESTARTED Actor ${self.path.name}")
     preStart()
     onRestart(reason)

--- a/fey-core/src/main/scala/org/apache/iota/fey/FeyGenericActor.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/FeyGenericActor.scala
@@ -82,13 +82,13 @@ abstract class FeyGenericActor(val params: Map[String,String] = Map.empty,
   }
 
   override final def preStart() = {
-    SYSTEM_ACTORS.monitoring  ! Monitor.START(Utils.getTimestamp)
+    SYSTEM_ACTORS.monitoring  ! Monitor.START(Utils.getTimestamp, startMonitorInfo)
     onStart()
     startScheduler()
   }
 
   override final def postStop() = {
-    SYSTEM_ACTORS.monitoring  ! Monitor.STOP(Utils.getTimestamp)
+    SYSTEM_ACTORS.monitoring  ! Monitor.STOP(Utils.getTimestamp, stopMonitorInfo)
     log.info(s"STOPPED actor ${self.path.name}")
     stopScheduler()
     onStop()
@@ -195,6 +195,20 @@ abstract class FeyGenericActor(val params: Map[String,String] = Map.empty,
     * @return
     */
   def customReceive: Receive
+
+
+  /**
+    * Used to set a info message when sending Stop monitor events
+    * @return String info
+    */
+  def stopMonitorInfo:String = "Stopped"
+
+  /**
+    * Used to set a info message when sending Start monitor events
+    * @return String info
+    */
+  def startMonitorInfo:String = "Started"
+
 }
 
 object FeyGenericActor {

--- a/fey-core/src/main/scala/org/apache/iota/fey/IdentifyFeyActors.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/IdentifyFeyActors.scala
@@ -82,7 +82,7 @@ protected object IdentifyFeyActors{
     */
   def generateTreeJson(): String = {
     val trie = new Trie()
-    actorsPath.map(_.replace("user/","")).foreach(trie.appendPath(_))
+    actorsPath.map(_.replace("user/","")).foreach(trie.append(_))
 
     Json.stringify(trie.print)
   }

--- a/fey-core/src/main/scala/org/apache/iota/fey/Monitor.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/Monitor.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iota.fey
+
+import akka.actor.{Actor, ActorLogging}
+
+/**
+  * Created by barbaragomes on 7/8/16.
+  */
+protected class Monitor extends Actor with ActorLogging{
+
+  import Monitor._
+
+  override def receive: Receive = {
+
+    case START(timestamp, info) =>
+      //TODO: Log
+      events.append(sender().path.toString,MonitorEvent(EVENTS.START, timestamp, info))
+
+    case STOP(timestamp, info) =>
+    //TODO: Log
+      events.append(sender().path.toString,MonitorEvent(EVENTS.STOP, timestamp, info))
+
+    case RESTART(reason, timestamp) =>
+    //TODO: Log
+      events.append(sender().path.toString,MonitorEvent(EVENTS.RESTART, timestamp, reason.getMessage))
+
+    case TERMINATE(actorPath, timestamp, info) =>
+    //TODO: Log
+      events.append(actorPath,MonitorEvent(EVENTS.TERMINATE, timestamp, info))
+
+  }
+
+}
+
+protected object Monitor{
+  // Monitoring Messages
+  case class START(timestamp: Long, info: String = "")
+  case class STOP(timestamp: Long, info: String = "")
+  case class RESTART(reason: Throwable, timestamp: Long)
+  case class TERMINATE(actorPath: String, timestamp: Long, info: String = "")
+
+  // Stores Monitoring event
+  case class MonitorEvent(event: String, timestamp: Long, info: String)
+
+  /**
+    * Contains the lifecycle events for actors in Fey
+    */
+  val events: Trie = new Trie()
+
+}
+
+/**
+  * Events Name
+  */
+object EVENTS {
+
+  val START = "START"
+  val STOP = "STOP"
+  val TERMINATE = "TERMINATE"
+  val RESTART = "RESTART"
+
+}
+
+

--- a/fey-core/src/main/scala/org/apache/iota/fey/MyService.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/MyService.scala
@@ -40,6 +40,7 @@ sealed trait MyService extends HttpService {
   val home = pathPrefix("fey")
   val activeActors = path("activeactors")
   val actorLifecycle = path("actorslifecycle")
+  val eventsTable = path("monitoringevents")
   val test = path("test")
 
   val myRoute =
@@ -61,6 +62,15 @@ sealed trait MyService extends HttpService {
           respondWithMediaType(`application/json`) {
             complete {
               Json.stringify(Monitor.events.printWithEvents)
+            }
+          }
+        }
+      } ~
+        eventsTable {
+        get{
+          respondWithMediaType(`text/html`) {
+            complete {
+              Monitor.getHTMLevents
             }
           }
         }

--- a/fey-core/src/main/scala/org/apache/iota/fey/MyService.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/MyService.scala
@@ -19,6 +19,7 @@ package org.apache.iota.fey
 
 import akka.actor.Actor
 import org.apache.iota.fey.FeyCore.JSON_TREE
+import play.api.libs.json.Json
 import spray.http.MediaTypes._
 import spray.routing._
 
@@ -38,6 +39,7 @@ sealed trait MyService extends HttpService {
 
   val home = pathPrefix("fey")
   val activeActors = path("activeactors")
+  val actorLifecycle = path("actorslifecycle")
   val test = path("test")
 
   val myRoute =
@@ -46,10 +48,19 @@ sealed trait MyService extends HttpService {
         get{
           respondWithMediaType(`text/html`) {
             complete {
-              Application.fey ! JSON_TREE
+              SYSTEM_ACTORS.fey ! JSON_TREE
               Thread.sleep(2000)
               val json = IdentifyFeyActors.generateTreeJson()
               IdentifyFeyActors.getHTMLTree(json)
+            }
+          }
+        }
+      } ~
+      actorLifecycle {
+        get{
+          respondWithMediaType(`application/json`) {
+            complete {
+              Json.stringify(Monitor.events.printWithEvents)
             }
           }
         }

--- a/fey-core/src/main/scala/org/apache/iota/fey/Orchestration.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/Orchestration.scala
@@ -50,6 +50,7 @@ protected class Orchestration(val name: String,
       context.actorSelection(s"*") ! Ensemble.PRINT_ENSEMBLE
 
     case Terminated(actor) =>
+      SYSTEM_ACTORS.monitoring  ! Monitor.TERMINATE(actor.path.toString, Utils.getTimestamp)
       context.unwatch(actor)
       log.warning(s"ACTOR DEAD ${actor.path}")
       ensembles.remove(actor.path.name)
@@ -68,16 +69,19 @@ protected class Orchestration(val name: String,
     }
 
   override def preStart(): Unit = {
+    SYSTEM_ACTORS.monitoring  ! Monitor.START(Utils.getTimestamp)
     if (ORCHESTRATION_CACHE.orchestration_metadata.contains(guid)){
       replayOrchestrationState()
     }
   }
 
   override def postStop() = {
+    SYSTEM_ACTORS.monitoring  ! Monitor.STOP(Utils.getTimestamp)
     log.info(s"STOPPED ${self.path.name}")
   }
 
   override def postRestart(reason: Throwable): Unit = {
+    SYSTEM_ACTORS.monitoring  ! Monitor.RESTART(reason, Utils.getTimestamp)
     log.info(s"RESTARTED ${self.path}")
     preStart()
   }

--- a/fey-core/src/main/scala/org/apache/iota/fey/TrieNode.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/TrieNode.scala
@@ -20,36 +20,43 @@ package org.apache.iota.fey
 import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
 
 import scala.annotation.tailrec
+import scala.collection.mutable.ArrayBuffer
 
 /**
   * Trie data structure used to create actors hierarchy in Fey
  */
-case class TrieNode(path: String, var children: Array[TrieNode])
+case class TrieNode(path: String, children: ArrayBuffer[TrieNode], events:ArrayBuffer[Monitor.MonitorEvent])
 
 class Trie{
 
-  private val root: TrieNode = TrieNode("FEY-MANAGEMENT-SYSTEM", Array.empty)
+  private val root: TrieNode = TrieNode("FEY-MANAGEMENT-SYSTEM", ArrayBuffer.empty, ArrayBuffer.empty)
   var elements: Int = 0
 
-  def appendPath(path: String): Unit = {
-    appendPath(path.replaceFirst("akka://","").split("/"),root,1)
+  def append(path: String, event: Monitor.MonitorEvent = null): Unit = {
+    append(path.replaceFirst("akka://","").split("/"),root,1,event)
   }
 
-  @tailrec private def appendPath(path: Array[String], root: TrieNode, index: Int): Unit = {
+  @tailrec private def append(path: Array[String], root: TrieNode, index: Int, event: Monitor.MonitorEvent): Unit = {
     if(root != null && index < path.length){
       var nextRoot = root.children.filter(child => child.path == path(index))
       if(nextRoot.isEmpty){
-        nextRoot = Array(TrieNode(path(index), Array.empty))
-        val children = root.children ++: nextRoot
-        root.children = children
+        nextRoot = ArrayBuffer(TrieNode(path(index), ArrayBuffer.empty, ArrayBuffer.empty))
+        root.children += nextRoot(0)
         elements += 1
       }
-      appendPath(path, nextRoot(0),index+1)
+      if(event != null && index == path.length - 1){
+        nextRoot(0).events += event
+      }
+      append(path, nextRoot(0),index+1, event)
     }
   }
 
   def print:JsValue = {
     getObject(root, null)
+  }
+
+  def printWithEvents:JsValue = {
+    getObjectEvent(root, null)
   }
 
   private def getObject(root: TrieNode, parent: TrieNode):JsObject = {
@@ -58,6 +65,23 @@ class Trie{
        "parent" -> (if(parent != null) parent.path else "null"),
         "children" -> root.children.map(getObject(_, root))
      )
+    }else{
+      Json.obj()
+    }
+  }
+
+  private def getObjectEvent(root: TrieNode, parent: TrieNode):JsObject = {
+    if(root != null) {
+      Json.obj("name" -> root.path,
+        "parent" -> (if(parent != null) parent.path else "null"),
+        "events" -> root.events.map(event => {
+          Json.obj("type" -> event.event,
+          "timestamp" -> event.timestamp,
+            "info" -> event.info
+          )
+        }),
+        "children" -> root.children.map(getObjectEvent(_, root))
+      )
     }else{
       Json.obj()
     }

--- a/fey-core/src/main/scala/org/apache/iota/fey/TrieNode.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/TrieNode.scala
@@ -59,6 +59,10 @@ class Trie{
     getObjectEvent(root, null)
   }
 
+  def getRootChildren():ArrayBuffer[TrieNode] = {
+    root.children
+  }
+
   private def getObject(root: TrieNode, parent: TrieNode):JsObject = {
     if(root != null) {
      Json.obj("name" -> root.path,

--- a/fey-core/src/main/scala/org/apache/iota/fey/Utils.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/Utils.scala
@@ -158,6 +158,12 @@ protected object Utils {
       }
     }
   }
+
+  /**
+    * timestamp in milliseconds
+    * @return Long
+    */
+  def getTimestamp:Long = System.currentTimeMillis()
 }
 
 object JSON_PATH{


### PR DESCRIPTION
Monitor actor receives lifecycle messages from all the actors on Fey and keeps track of the timestamp. It also offers two APIs:

- Returns a JSON contain the events information for each actor
- Display a draft table with the actors events