### PR TITLE
[IOTA-36] Global Performers

### DIFF
--- a/fey-core/src/main/resources/fey-json-schema-validator.json
+++ b/fey-core/src/main/resources/fey-json-schema-validator.json
@@ -13,6 +13,101 @@
   "name":{
     "type":"string"
   },
+  "global-performers":{
+    "type":"array",
+    "items": {
+      "guid": {
+        "type": "string"
+      },
+      "controlAware": {
+        "type": "boolean"
+      },
+      "dispatcher": {
+        "type": "string"
+      },
+      "autoScale": {
+        "type": "object",
+        "lowerBound": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "upperBound": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "backoffThreshold": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "roundRobin": {
+          "type": "boolean"
+        },
+        "required": [
+          "lowerBound",
+          "upperBound"
+        ]
+      },
+      "schedule": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "backoff": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "source": {
+        "type": "object",
+        "name": {
+          "type": "string",
+          "pattern": "\\w+(\\.jar)"
+        },
+        "location": {
+          "type": "object",
+          "url": {
+            "type": "string",
+            "pattern": "(?i)(^(http|https|file)):\/\/"
+          },
+          "credentials": {
+            "user": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "required": [
+              "user",
+              "password"
+            ]
+          },
+          "required": [
+            "url"
+          ]
+        },
+        "classPath": {
+          "type": "string",
+          "pattern": "\\w+"
+        },
+        "parameters": {
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "name",
+          "classPath",
+          "parameters"
+        ]
+      },
+      "required":[
+        "guid",
+        "schedule",
+        "backoff",
+        "source"
+      ]
+    }
+  },
   "ensembles":{
     "type":"array",
     "items":{

--- a/fey-core/src/main/scala/org/apache/iota/fey/Ensemble.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/Ensemble.scala
@@ -162,13 +162,8 @@ protected class Ensemble(val orchestrationID: String,
     * @return (performerID, ActorRef of the performer)
     */
   private def createFeyActor(performerID: String, connectionIDs: Array[String], tmpActors:HashMap[String, ActorRef]):(String, ActorRef) = {
-    // Performer is a global performer and is already created
-    if(GlobalPerformer.activeGlobalPerformers.contains(orchestrationID)
-      && GlobalPerformer.activeGlobalPerformers.get(orchestrationID).get.contains(performerID)){
-      (performerID, GlobalPerformer.activeGlobalPerformers.get(orchestrationID).get.get(performerID).get)
-    }
-      // performer was already created
-    else if(tmpActors.contains(performerID)){
+    // performer was already created
+    if(tmpActors.contains(performerID)){
       (performerID, tmpActors.get(performerID).get)
     }
     else{
@@ -204,7 +199,13 @@ protected class Ensemble(val orchestrationID: String,
         tmpActors.put(performerID, actor)
         (performerID, actor)
       }else{
-        throw new IllegalPerformerCreation(s"Performer $performerID is not defined in the JSON")
+        // Performer is a global performer and is already created
+        if(GlobalPerformer.activeGlobalPerformers.contains(orchestrationID)
+          && GlobalPerformer.activeGlobalPerformers.get(orchestrationID).get.contains(performerID)){
+          (performerID, GlobalPerformer.activeGlobalPerformers.get(orchestrationID).get.get(performerID).get)
+        }else {
+          throw new IllegalPerformerCreation(s"Performer $performerID is not defined in the JSON")
+        }
       }
     }
   }

--- a/fey-core/src/main/scala/org/apache/iota/fey/FeyCore.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/FeyCore.scala
@@ -102,6 +102,7 @@ protected class FeyCore extends Actor with ActorLogging{
     FEY_CACHE.activeOrchestrations.remove(actorRef.path.name)
     ORCHESTRATION_CACHE.orchestration_metadata.remove(actorRef.path.name)
     ORCHESTRATION_CACHE.orchestration_globals.remove(actorRef.path.name)
+    GlobalPerformer.activeGlobalPerformers.remove(actorRef.path.name)
     if(!FEY_CACHE.orchestrationsAwaitingTermination.isEmpty) {
       checkForOrchestrationWaitingForTermination(actorRef.path.name)
     }

--- a/fey-core/src/main/scala/org/apache/iota/fey/GlobalPerformer.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/GlobalPerformer.scala
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iota.fey
+
+import akka.actor.SupervisorStrategy.Restart
+import akka.actor.{Actor, ActorLogging, ActorRef, OneForOneStrategy, Props, Terminated}
+import akka.routing._
+import play.api.libs.json.JsObject
+
+import scala.collection.mutable.HashMap
+import scala.concurrent.duration._
+
+protected class GlobalPerformer(val orchestrationID: String,
+                                val orchestrationName: String,
+                                val globalPerformers: List[JsObject],
+                                val ensemblesSpec :  List[JsObject]) extends Actor with ActorLogging{
+
+  val monitoring_actor = FEY_MONITOR.actorRef
+  var global_metadata: Map[String, Performer] = Map.empty[String, Performer]
+  var global_performer: Map[String,ActorRef] = Map.empty[String,ActorRef]
+
+  override def receive: Receive = {
+
+    case GlobalPerformer.PRINT_GLOBAL =>
+      context.actorSelection(s"*") ! FeyGenericActor.PRINT_PATH
+
+    case Terminated(actor) =>
+      monitoring_actor  ! Monitor.TERMINATE(actor.path.toString, Utils.getTimestamp)
+      log.error(s"DEAD Global Performers ${actor.path.name}")
+      context.children.foreach{ child =>
+        context.unwatch(child)
+        context.stop(child)
+      }
+      throw new RestartGlobalPerformers(s"DEAD Global Performer ${actor.path.name}")
+
+    case GetRoutees => //Discard
+
+    case x => log.warning(s"Message $x not treated by Global Performers")
+  }
+
+  /**
+    * If any of the global performer dies, it tries to restart it.
+    * If we could not be restarted, then the terminated message will be received
+    * and Global Performer is going to throw an Exception to its orchestration
+    * asking it to Restart all the entire orchestration. The restart will then stop all of its
+    * children when call the preStart.
+    */
+  override val supervisorStrategy =
+  OneForOneStrategy(maxNrOfRetries = 3, withinTimeRange = 1 minute) {
+    case e: Exception => Restart
+  }
+
+  /**
+    * Uses the json spec to create the performers
+    */
+  override def preStart() : Unit = {
+
+    monitoring_actor ! Monitor.START(Utils.getTimestamp)
+
+    global_metadata = Ensemble.extractPerformers(globalPerformers)
+
+    createGlobalPerformers()
+
+  }
+
+  override def postStop() : Unit = {
+    monitoring_actor  ! Monitor.STOP(Utils.getTimestamp)
+  }
+
+  override def postRestart(reason: Throwable): Unit = {
+    monitoring_actor  ! Monitor.RESTART(reason, Utils.getTimestamp)
+    preStart()
+  }
+
+  private def createGlobalPerformers() = {
+    try {
+      global_metadata.foreach((global_performer) => {
+        createFeyActor(global_performer._1, global_performer._2)
+      })
+      context.parent ! Orchestration.CREATE_ENSEMBLES(ensemblesSpec)
+    } catch {
+      /* if the creation fails, it will stop the orchestration */
+      case e: Exception =>
+        log.error(e,"During Global Manager creation")
+        throw new RestartGlobalPerformers("Could not create global performer")
+    }
+  }
+
+  private def createFeyActor(performerID: String, performerInfo: Performer) = {
+    val actor: ActorRef = {
+      val actorProps = getPerformer(performerInfo)
+      if (performerInfo.autoScale) {
+
+        val resizer = DefaultResizer(lowerBound = performerInfo.lowerBound, upperBound = performerInfo.upperBound,
+          messagesPerResize = CONFIG.MESSAGES_PER_RESIZE, backoffThreshold = performerInfo.backoffThreshold, backoffRate = 0.1)
+
+        val strategy =
+          if (performerInfo.isRoundRobin) {
+            log.info(s"Using Round Robin for performer ${performerID}")
+            RoundRobinPool(1, Some(resizer))
+          } else {
+            log.info(s"Using Smallest mailbox for performer ${performerID}")
+            SmallestMailboxPool(1, Some(resizer))
+          }
+
+        context.actorOf(strategy.props(actorProps), name = performerID)
+      } else {
+        context.actorOf(actorProps, name = performerID)
+      }
+    }
+
+    context.watch(actor)
+    GlobalPerformer.activeGlobalPerformers.get(orchestrationID) match {
+      case Some(globals) => GlobalPerformer.activeGlobalPerformers.put(orchestrationID, (globals ++ Map(performerID -> actor)))
+      case None => GlobalPerformer.activeGlobalPerformers.put(orchestrationID, Map(performerID -> actor))
+    }
+  }
+
+  /**
+    * Creates actor props based on JSON configuration
+    *
+    * @param performerInfo Performer object
+    * @return Props of actor based on JSON config
+    */
+  private def getPerformer(performerInfo: Performer): Props = {
+
+    val clazz = loadClazzFromJar(performerInfo.classPath, s"${performerInfo.jarLocation}/${performerInfo.jarName}", performerInfo.jarName)
+
+    val dispatcher = if(performerInfo.dispatcher != "") s"fey-custom-dispatchers.${performerInfo.dispatcher}" else ""
+
+    val actorProps = Props(clazz,
+      performerInfo.parameters, performerInfo.backoff, Map.empty, performerInfo.schedule, orchestrationName, orchestrationID, performerInfo.autoScale)
+
+    // dispatcher has higher priority than controlAware. That means that if both are defined
+    // then the custom dispatcher will be used
+    if(dispatcher != ""){
+      log.info(s"Using dispatcher: $dispatcher")
+      actorProps.withDispatcher(dispatcher)
+    }
+    else if(performerInfo.controlAware){
+      actorProps.withDispatcher(CONFIG.CONTROL_AWARE_MAILBOX)
+    }else{
+      actorProps
+    }
+  }
+
+  /**
+    * Load a clazz instance of FeyGenericActor from a jar
+    *
+    * @param classPath class path
+    * @param jarLocation Full path where to load the jar from
+    * @return clazz instance of FeyGenericActor
+    */
+  private def loadClazzFromJar(classPath: String, jarLocation: String, jarName: String):Class[FeyGenericActor] = {
+    try {
+      Utils.loadActorClassFromJar(jarLocation,classPath,jarName)
+    }catch {
+      case e: Exception =>
+        log.error(e,s"Could not load class $classPath from jar $jarLocation. Please, check the Jar repository path as well the jar name")
+        throw e
+    }
+  }
+
+}
+
+object GlobalPerformer{
+
+  val activeGlobalPerformers:HashMap[String, Map[String, ActorRef]] = HashMap.empty[String, Map[String, ActorRef]]
+
+  case object PRINT_GLOBAL
+}

--- a/fey-core/src/main/scala/org/apache/iota/fey/Utils.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/Utils.scala
@@ -201,6 +201,7 @@ object JSON_PATH{
   val JAR_CRED_USER = "user"
   val JAR_CRED_PASSWORD = "password"
   val PERFORMER_DISPATCHER = "dispatcher"
+  val GLOBAL_PERFORMERS = "global-performers"
 }
 
 object CONFIG{
@@ -329,3 +330,5 @@ case class IllegalPerformerCreation(message:String)  extends Exception(message)
 case class NetworkNotDefined(message:String)  extends Exception(message)
 case class CommandNotRecognized(message:String)  extends Exception(message)
 case class RestartEnsemble(message:String)  extends Exception(message)
+case class RestartGlobalPerformers(message: String) extends  Exception(message)
+case class RestartOrchestration(message: String) extends  Exception(message)

--- a/fey-core/src/test/scala/org/apache/iota/fey/FeyCoreSpec.scala
+++ b/fey-core/src/test/scala/org/apache/iota/fey/FeyCoreSpec.scala
@@ -275,6 +275,23 @@ class FeyCoreSpec extends BaseAkkaSpec  {
       TestProbe().expectActor(s"$feyPath/$global_orch_name/ENS-GLOBAL/PERFORMER-SCHEDULER")
       TestProbe().expectActor(s"$feyPath/$global_orch_name/ENS-GLOBAL")
     }
+    "all previous actors restarted" in {
+      val routee = """$a"""
+      val routee2 = """$b"""
+      val routee3 = """$c"""
+      val routee4 = """$d"""
+      globalIdentifierRef ! IdentifyFeyActors.IDENTIFY_TREE(s"${feyCoreRef.path.toString}/$global_orch_name")
+      Thread.sleep(500)
+      IdentifyFeyActors.actorsPath should have size (8)
+      IdentifyFeyActors.actorsPath should contain(s"$feyPath/$global_orch_name/GLOBAL_MANAGER")
+      IdentifyFeyActors.actorsPath should contain(s"$feyPath/$global_orch_name/GLOBAL_MANAGER/GLOBAL-TEST")
+      IdentifyFeyActors.actorsPath should contain(s"$feyPath/$global_orch_name/ENS-GLOBAL")
+      IdentifyFeyActors.actorsPath should contain(s"$feyPath/$global_orch_name/ENS-GLOBAL/PERFORMER-SCHEDULER")
+      IdentifyFeyActors.actorsPath should contain(s"$feyPath/$global_orch_name/ENS-GLOBAL/PERFORMER-SCHEDULER/$routee")
+      IdentifyFeyActors.actorsPath should contain(s"$feyPath/$global_orch_name/ENS-GLOBAL/PERFORMER-SCHEDULER/$routee2")
+      IdentifyFeyActors.actorsPath should contain(s"$feyPath/$global_orch_name/ENS-GLOBAL/PERFORMER-SCHEDULER/$routee3")
+      IdentifyFeyActors.actorsPath should contain(s"$feyPath/$global_orch_name/ENS-GLOBAL/PERFORMER-SCHEDULER/$routee4")
+    }
   }
 
   "Stopping orchestration with global performer" should {

--- a/fey-core/src/test/scala/org/apache/iota/fey/GlobalPerformerSpec.scala
+++ b/fey-core/src/test/scala/org/apache/iota/fey/GlobalPerformerSpec.scala
@@ -45,6 +45,9 @@ class GlobalPerformerSpec extends BaseAkkaSpec{
   var global_managerRef:TestActorRef[GlobalPerformer] = null
   var global_managerState:GlobalPerformer = null
 
+  var ensembleglobal:ActorRef = null
+  var childPerformer:ActorRef = null
+  var globalPerformer: ActorRef = null
 
   "Creating an Global Manager " should {
     "result in sending START message to Monitor actor" in {
@@ -53,6 +56,101 @@ class GlobalPerformerSpec extends BaseAkkaSpec{
       }), orchRef, global_name)
       global_managerState = global_managerRef.underlyingActor
       monitor.expectMsgClass(1.seconds, classOf[Monitor.START])
+    }
+    s"result in creating an Orchestration child actor with the name '$orch_id'" in {
+      TestProbe().expectActor(s"${orchRef.path.toString}")
+    }
+    s"result in creating an Ensemble child actor with the name '${orchRef.path.toString}/ENS-GLOBAL'" in {
+      ensembleglobal = TestProbe().expectActor(s"${orchRef.path.toString}/ENS-GLOBAL")
+    }
+    s"result in creating a global Performer child actor with the name '${orchRef.path.toString}/GLOBAL_MANAGER/GLOBAL-TEST'" in {
+      globalPerformer = TestProbe().expectActor(s"${orchRef.path.toString}/$global_name/GLOBAL-TEST")
+      TestProbe().expectActor(s"${orchRef.path.toString}/$global_name")
+    }
+    s"result in creating a Performer child actor with the name '${orchRef.path.toString}/ENS-GLOBAL/PERFORMER-SCHEDULER'" in {
+      childPerformer = TestProbe().expectActor(s"${orchRef.path.toString}/ENS-GLOBAL/PERFORMER-SCHEDULER")
+    }
+    s"result in one global actor created for orchestration" in {
+      GlobalPerformer.activeGlobalPerformers should have size(1)
+      GlobalPerformer.activeGlobalPerformers should contain key(orch_id)
+    }
+    s"result in right number of running actors" in {
+      globalIdentifierRef ! IdentifyFeyActors.IDENTIFY_TREE(parent.ref.path.toString)
+      Thread.sleep(500)
+      IdentifyFeyActors.actorsPath should have size (9)
+      IdentifyFeyActors.actorsPath should contain(s"${orchRef.path.toString}")
+      IdentifyFeyActors.actorsPath should contain(s"${orchRef.path.toString}/GLOBAL-MANAGER")
+      IdentifyFeyActors.actorsPath should contain(s"${orchRef.path.toString}/GLOBAL-MANAGER/GLOBAL-TEST")
+      IdentifyFeyActors.actorsPath should contain(s"${orchRef.path.toString}/ENS-GLOBAL")
+      IdentifyFeyActors.actorsPath should contain(s"${orchRef.path.toString}/ENS-GLOBAL/PERFORMER-SCHEDULER")
+    }
+  }
+
+  "Stopping performer inside ensemble" should {
+    "Send stop message to monitor" in {
+      EventFilter.error(pattern = s".*DEAD nPerformers.*", occurrences = 1) intercept {
+        childPerformer ! PoisonPill
+      }
+      //Restarted ensemble
+      monitor.expectMsgClass(1.seconds, classOf[Monitor.START])
+    }
+  }
+
+  "Stopping ensemble" should {
+    "Send stop message to monitor" in {
+      EventFilter.warning(pattern = s".*ACTOR DEAD.*", occurrences = 1) intercept {
+        ensembleglobal ! PoisonPill
+      }
+      //Restarted ensemble
+      monitor.expectMsgClass(1.seconds, classOf[Monitor.TERMINATE])
+    }
+    "result in no orchestration running" in {
+      globalIdentifierRef ! IdentifyFeyActors.IDENTIFY_TREE(parent.ref.path.toString)
+      Thread.sleep(500)
+      IdentifyFeyActors.actorsPath should have size (3)
+      IdentifyFeyActors.actorsPath should not contain(s"${orchRef.path.toString}/ENS-GLOBAL")
+    }
+    "not affect global performer" in {
+      globalIdentifierRef ! IdentifyFeyActors.IDENTIFY_TREE(parent.ref.path.toString)
+      Thread.sleep(500)
+      IdentifyFeyActors.actorsPath should have size (3)
+      IdentifyFeyActors.actorsPath should contain(s"${orchRef.path.toString}")
+      IdentifyFeyActors.actorsPath should contain(s"${orchRef.path.toString}/GLOBAL-MANAGER")
+      IdentifyFeyActors.actorsPath should contain(s"${orchRef.path.toString}/GLOBAL-MANAGER/GLOBAL-TEST")
+    }
+  }
+
+  "Stopping global performer" should {
+    "result in restart the orchestration" in {
+      EventFilter.error(pattern = s".*DEAD Global Performers.*", occurrences = 1) intercept {
+        globalPerformer ! PoisonPill
+      }
+      monitor.expectMsgClass(1.seconds, classOf[Monitor.TERMINATE])
+    }
+    "all previous actors restarted" in {
+      globalIdentifierRef ! IdentifyFeyActors.IDENTIFY_TREE(parent.ref.path.toString)
+      Thread.sleep(500)
+      IdentifyFeyActors.actorsPath should have size (7)
+      IdentifyFeyActors.actorsPath should contain(s"${orchRef.path.toString}")
+      //TestProbe does not contain the right supervisor estrategy to restart global
+      //IdentifyFeyActors.actorsPath should contain(s"${orchRef.path.toString}/GLOBAL-MANAGER")
+      //IdentifyFeyActors.actorsPath should contain(s"${orchRef.path.toString}/GLOBAL-MANAGER/GLOBAL-TEST")
+      IdentifyFeyActors.actorsPath should contain(s"${orchRef.path.toString}/ENS-GLOBAL")
+      IdentifyFeyActors.actorsPath should contain(s"${orchRef.path.toString}/ENS-GLOBAL/PERFORMER-SCHEDULER")
+    }
+  }
+
+  "Stopping orchestration" should {
+    "result in empty global" in {
+      orchRef ! PoisonPill
+      GlobalPerformer.activeGlobalPerformers.remove("GLOBAL-ORCH")
+      globalIdentifierRef ! IdentifyFeyActors.IDENTIFY_TREE(parent.ref.path.toString)
+      Thread.sleep(500)
+      IdentifyFeyActors.actorsPath should not contain(s"${orchRef.path.toString}/ENS-GLOBAL")
+      IdentifyFeyActors.actorsPath should not contain(s"${orchRef.path.toString}/GLOBAL-MANAGER")
+      IdentifyFeyActors.actorsPath should not contain(s"${orchRef.path.toString}/GLOBAL-MANAGER/GLOBAL-TEST")
+
+      GlobalPerformer.activeGlobalPerformers should have size(0)
     }
   }
 }

--- a/fey-core/src/test/scala/org/apache/iota/fey/GlobalPerformerSpec.scala
+++ b/fey-core/src/test/scala/org/apache/iota/fey/GlobalPerformerSpec.scala
@@ -1,0 +1,58 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iota.fey
+
+import play.api.libs.json._
+import akka.actor.{ActorRef, PoisonPill, Props}
+import akka.testkit.{EventFilter, TestActorRef, TestProbe}
+
+import scala.concurrent.duration.DurationInt
+
+class GlobalPerformerSpec extends BaseAkkaSpec{
+
+  // Orchestration that is the parent of ensembles and global
+  val orch_id = "GLOBAL-ORCH"
+  val parent = TestProbe("CORE")
+
+  val monitor = TestProbe()
+
+  val orchRef = TestActorRef[Orchestration]( Props(new Orchestration("TESTING-GLOBAL",orch_id,"123124324324"){
+    override val monitoring_actor = monitor.ref
+  }), parent.ref, orch_id)
+  val orchState = orchRef.underlyingActor
+
+  val orchestrationJson = getJSValueFromString(Utils_JSONTest.global_perf_test)
+  val ensembles = (orchestrationJson \ JSON_PATH.ENSEMBLES).as[List[JsObject]]
+  val globals = (orchestrationJson \ JSON_PATH.GLOBAL_PERFORMERS).as[List[JsObject]]
+
+  val global_name = "GLOBAL-MANAGER"
+  var global_managerRef:TestActorRef[GlobalPerformer] = null
+  var global_managerState:GlobalPerformer = null
+
+
+  "Creating an Global Manager " should {
+    "result in sending START message to Monitor actor" in {
+      global_managerRef =  TestActorRef[GlobalPerformer]( Props(new GlobalPerformer(orch_id,"TESTING-GLOBAL",globals,ensembles){
+        override val monitoring_actor = monitor.ref
+      }), orchRef, global_name)
+      global_managerState = global_managerRef.underlyingActor
+      monitor.expectMsgClass(1.seconds, classOf[Monitor.START])
+    }
+  }
+}

--- a/fey-core/src/test/scala/org/apache/iota/fey/UtilsSpec.scala
+++ b/fey-core/src/test/scala/org/apache/iota/fey/UtilsSpec.scala
@@ -26,6 +26,7 @@ import ch.qos.logback.classic.Level
 import play.api.libs.json._
 import java.nio.file.{Files, Paths}
 
+import scala.collection.mutable
 import scala.io.Source
 import scala.concurrent.duration._
 
@@ -33,6 +34,7 @@ class UtilsSpec extends BaseAkkaSpec{
 
   "Global variable loadedJars" should{
     "be empty when starting" in {
+      Utils.loadedJars.remove("fey-test-actor.jar")
       Utils.loadedJars shouldBe empty
     }
   }

--- a/fey-core/src/test/scala/org/apache/iota/fey/Utils_JSONTest.scala
+++ b/fey-core/src/test/scala/org/apache/iota/fey/Utils_JSONTest.scala
@@ -551,4 +551,61 @@ object Utils_JSONTest {
          }
        ]
      }"""
+
+
+  val global_perf_test =
+    """
+      {
+        "guid":"GLOBAL-PERFORMER",
+        "command":"RECREATE",
+        "timestamp":"12347896906",
+        "name":"recreate global",
+        "global-performers":[
+          {
+            "guid":"GLOBAL-TEST",
+            "schedule":0,
+            "backoff":1000,
+            "source":{
+              "name":"fey-test-actor.jar",
+              "classPath":"org.apache.iota.fey.TestActor",
+              "parameters":{
+                "param-1":"test",
+                "param-2":"test2"
+              }
+            }
+          }
+        ],
+        "ensembles":[
+          {
+            "guid":"ENS-GLOBAL",
+            "command":"NONE",
+            "performers":[
+              {
+                "guid":"PERFORMER-SCHEDULER",
+                "schedule":200,
+                "backoff":0,
+                "autoScale":{
+                  "lowerBound":4,
+                  "upperBound":6
+                },
+                "source":{
+                  "name":"fey-test-actor.jar",
+                  "classPath":"org.apache.iota.fey.TestActor",
+                  "parameters":{
+
+                  }
+                }
+              }
+            ],
+            "connections":[
+              {
+                "PERFORMER-SCHEDULER":[
+                  "GLOBAL-TEST"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    """
 }


### PR DESCRIPTION
Capability of specifying Global Performers that can be used by any ensemble.

- JSON: at root level add "global-performers" property. It is an array of objects exactly like the "performers" property. (Optional)
- Ensemble gives priority to the local performers over the Global ones
- Global can not connect to, it only receives connections (deadlock issue)
- Unit tests

Note: Updating orchestration with global performers may not be working properly.