### PR TITLE
IOTA-37: Add files required for an Apache release.

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -4,3 +4,15 @@
 # git files
 .gitignore
 .gitattributes
+# Readme files
+Readme.*
+README.*
+RAT_README
+# JSON files
+fey-json-schema-validator
+invalid-json.json
+raspberry-pi.json
+temperature.json
+timestamp.json
+valid-json.json
+

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -1,0 +1,6 @@
+# List of files to exclude from RAT, see RAT_README for details
+# this file
+.rat-excludes*
+# git files
+.gitignore
+.gitattributes

--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,0 +1,11 @@
+Apache iota is an effort undergoing incubation at The Apache Software 
+Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is 
+required of all newly accepted projects until a further review indicates that 
+the infrastructure, communications, and decision making process have stabilized
+in a manner consistent with other successful ASF projects. While incubation 
+status is not necessarily a reflection of the completeness or stability of the
+code, it does indicate that the project has yet to be fully endorsed by the ASF.
+
+For more information about the incubation status of the Apache iota see:
+   http://incubator.apache.org/projects/iota.html
+

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,8 @@
+Apache iota
+Copyright 2016-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+In addition, this product includes software developed by
+Copyright 2014-2016 Litbit

--- a/RAT_README
+++ b/RAT_README
@@ -1,0 +1,27 @@
+================================================================================
+RAT_README
+
+This file contains the list of excluded files that do not contain Apache 
+headers, what these files are used for, and why they don't have Apache headers
+================================================================================
+
+
+To run the RAT report:
+
+1. Install Apache Rat download version 0.11 from  http://creadur.apache.org/rat/
+
+2. Assuming that the iota source tree is in apache-iota-XXX directory,
+   run rat as follows:
+
+  java -jar apache-rat-0.11/apache-rat-0.11.jar  -E apache-iota-XXX/.rat-excludes \
+       -d apache-iota-XXX > rat.out
+
+3. Look at output in rat.out log file for issues
+
+================================================================================
+
+
+--------------------------------------------------------------------------------
+FILE             :  what the file is used for
+                 -> reason why file is excluded
+--------------------------------------------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
             <attributes>
               <imagesdir>./images</imagesdir>
               <icons>font</icons>
-              <stylesheet>trafodion.css</stylesheet>
+              <stylesheet>iota.css</stylesheet>
               <last-update-label>false</last-update-label>
             </attributes>
           </configuration>
@@ -229,7 +229,7 @@
                 <attributes>
                   <imagesdir>./images</imagesdir>
                   <icons>font</icons>
-                  <stylesheet>trafodion.css</stylesheet>
+                  <stylesheet>iota.css</stylesheet>
                   <last-update-label>false</last-update-label>
                 </attributes>
                 <backend>html5</backend>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,281 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*
+ * @@@ START COPYRIGHT @@@
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * @@@ END COPYRIGHT @@@
+ *
+ */
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>16</version>
+    <relativePath/>
+      <!-- no parent resolution -->
+  </parent>
+
+  <groupId>org.apache.iota</groupId>
+  <artifactId>iota</artifactId>
+  <version>0.1</version>
+  <packaging>pom</packaging>
+  <name>Apache iota</name>
+  <description>Apache iota is a general platform for orchestrating IoT devices in both consumer and industrial contexts.</description>
+  <url>http://iota.incubator.apache.org</url>
+  <inceptionYear>2016</inceptionYear>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+      <comments>A business-friendly OSS license</comments>
+    </license>
+  </licenses>
+
+  <organization>
+    <name>Apache Software Foundation</name>
+    <url>http://www.apache.org</url>
+  </organization>
+
+  <issueManagement>
+    <system>JIRA</system>
+    <url>http://issues.apache.org/jira/browse/iota</url>
+  </issueManagement>
+
+  <scm>
+    <connection>scm:git:http://git-wip-us.apache.org/repos/asf/incubator-iota.git</connection>
+    <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/incubator-iota.git</developerConnection>
+    <url>https://git-wip-us.apache.org/repos/asf?p=incubator-iota.git</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <ciManagement>
+    <system>Jenkins</system>
+    <url>https://jenkins.esgyn.com</url>
+  </ciManagement>
+
+  <mailingLists>
+    <mailingList>
+      <name>User List</name>
+      <subscribe>user-subscribe@iota.incubator.apache.org</subscribe>
+      <unsubscribe>user-unsubscribe@iota.incubator.apache.org</unsubscribe>
+      <post>user@iota.incubator.apache.org</post>
+      <archive>http://mail-archives.apache.org/mod_mbox/incubator-iota-user/</archive>
+    </mailingList>
+    <mailingList>
+      <name>Developer List</name>
+      <subscribe>dev-subscribe@iota.incubator.apache.org</subscribe>
+      <unsubscribe>dev-unsubscribe@iota.incubator.apache.org</unsubscribe>
+      <post>dev@iota.incubator.apache.org</post>
+      <archive>http://mail-archives.apache.org/mod_mbox/incubator-iota-dev/</archive>
+    </mailingList>
+    <mailingList>
+      <name>GitHub Codereview List</name>
+      <subscribe>codereview-subscribe@iota.incubator.apache.org</subscribe>
+      <unsubscribe>codereview-unsubscribe@iota.incubator.apache.org</unsubscribe>
+      <archive>http://mail-archives.apache.org/mod_mbox/incubator-iota-codereview/</archive>
+    </mailingList>
+    <mailingList>
+      <name>Commits List</name>
+      <subscribe>commits-subscribe@iota.incubator.apache.org</subscribe>
+      <unsubscribe>commits-unsubscribe@iota.incubator.apache.org</unsubscribe>
+      <archive>http://mail-archives.apache.org/mod_mbox/incubator-iota-commits/</archive>
+    </mailingList>
+    <mailingList>
+      <name>Issues List</name>
+      <subscribe>issues-subscribe@iota.incubator.apache.org</subscribe>
+      <unsubscribe>issues-unsubscribe@iota.incubator.apache.org</unsubscribe>
+      <archive>http://mail-archives.apache.org/mod_mbox/incubator-iota-issues/</archive>
+    </mailingList>
+  </mailingLists>
+
+  <developers>
+    <developer>
+      <id>iotaDeveloper</id>
+      <name>See list of iota developers</name>
+      <email>dev@iota.incubator.apache.org</email>
+      <url>https://cwiki.apache.org/confluence/display/IOTA/Contributors</url>
+    </developer>
+  </developers>
+
+  <contributors>
+    <contributor>
+      <name>See list of iota contributors</name>
+      <email>dev@iota.incubator.apache.org</email>
+      <url>https://cwiki.apache.org/confluence/display/IOTA/Contributors</url>
+    </contributor>
+  </contributors>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+
+  <!--modules>
+    <module>docs/install_guide</module>
+  </modules-->
+
+  <build>
+    <resources>
+      <resource>
+        <directory>${basedir}/docs/src/site/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <outputDirectory>${basedir}/docs/target</outputDirectory>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.7</version>
+          <configuration>
+            <encoding>UTF-8</encoding>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.4</version>
+          <inherited>false</inherited>
+          <dependencies>
+            <dependency>
+              <!-- add support for ssh/scp -->
+              <groupId>org.apache.maven.wagon</groupId>
+              <artifactId>wagon-ssh</artifactId>
+              <version>2.2</version>
+            </dependency>
+            <!-- Markdown is used for the website pages -->
+            <dependency>
+               <groupId>org.apache.maven.doxia</groupId>
+               <artifactId>doxia-module-markdown</artifactId>
+               <version>1.6</version>
+            </dependency>
+            <dependency>
+              <groupId>lt.velykis.maven.skins</groupId>
+              <artifactId>reflow-velocity-tools</artifactId>
+              <version>1.1.1</version>
+            </dependency>
+            <!-- Reflow skin requires Velocity >= 1.7  -->
+            <dependency>
+              <groupId>org.apache.velocity</groupId>
+              <artifactId>velocity</artifactId>
+              <version>1.7</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <siteDirectory>${basedir}/docs/src/site</siteDirectory>
+            <outputDirectory>${basedir}/docs/target</outputDirectory>
+            <inputEncoding>UTF-8</inputEncoding>
+            <outputEncoding>UTF-8</outputEncoding>
+            <attributes>
+              <imagesdir>./images</imagesdir>
+              <icons>font</icons>
+              <stylesheet>trafodion.css</stylesheet>
+              <last-update-label>false</last-update-label>
+            </attributes>
+          </configuration>
+        </plugin>
+        <!-- For AsciiDoc docs building -->
+        <plugin>
+          <groupId>org.asciidoctor</groupId>
+          <artifactId>asciidoctor-maven-plugin</artifactId>
+          <version>1.5.2</version>
+          <inherited>false</inherited>
+          <dependencies>
+            <dependency>
+              <groupId>org.asciidoctor</groupId>
+              <artifactId>asciidoctorj-pdf</artifactId>
+              <version>1.5.2</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <outputDirectory>${basedir}/docs/target/docs</outputDirectory>
+            <doctype>book</doctype>
+            <imagesDir>images</imagesDir>
+            <sourceHighlighter>coderay</sourceHighlighter>
+            <attributes>
+              <docVersion>${project.version}</docVersion>
+            </attributes>
+          </configuration>
+          <executions>
+            <execution>
+              <id>output-html</id>
+              <phase>site</phase>
+              <goals>
+                <goal>process-asciidoc</goal>
+              </goals>
+              <configuration>
+                <attributes>
+                  <imagesdir>./images</imagesdir>
+                  <icons>font</icons>
+                  <stylesheet>trafodion.css</stylesheet>
+                  <last-update-label>false</last-update-label>
+                </attributes>
+                <backend>html5</backend>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <reporting>
+    <excludeDefaults>true</excludeDefaults>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>2.8</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>project-team</report>
+              <report>mailing-list</report>
+              <report>issue-tracking</report>
+              <report>license</report>
+              <report>summary</report>
+              <report>scm</report>
+              <report>cim</report>
+              <report>modules</report>
+              <report>dependencies</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
+
+  <distributionManagement>
+    <site>
+      <id>iota.incubator.apache.org</id>
+      <name>iota Website at incubator.apache.org</name>
+      <!-- On why this is the tmp dir and not iota.incubator.apache.org, see
+      https://issues.apache.org/jira/browse/HBASE-7593?focusedCommentId=13555866&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13555866
+      -->
+      <url>file:///tmp</url>
+    </site>
+  </distributionManagement>
+
+</project>


### PR DESCRIPTION
NOTICE files guesses age of Litbit code donation.

RAT_README and .rat-excludes are placeholders.

pom.xml prepares for generating project information from build and to move release-dependent documentation into the source tree. For now, asciidoc is assumed as the tool of choice for documentation. 