### PR TITLE
IOTA-41: Spring dependency injection for fey performers

### DIFF
--- a/fey-core/src/main/resources/FeyApplicationContext.xml
+++ b/fey-core/src/main/resources/FeyApplicationContext.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans  http://www.springframework.org/schema/beans/spring-beans.xsd
+	   					   http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+
+    <context:annotation-config />
+
+</beans>

--- a/fey-core/src/main/resources/fey-json-schema-validator.json
+++ b/fey-core/src/main/resources/fey-json-schema-validator.json
@@ -87,6 +87,9 @@
           "type": "string",
           "pattern": "\\w+"
         },
+        "contextPath": {
+          "type": "string"
+        },
         "parameters": {
           "patternProperties": {
             ".*": {

--- a/fey-core/src/main/scala/org/apache/iota/fey/FeyGenericSpringActor.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/FeyGenericSpringActor.scala
@@ -33,11 +33,11 @@ abstract class FeyGenericSpringActor(override val params: Map[String,String] = M
                                     override val autoScale: Boolean = false,
                                     val appContextPath: String = "") extends FeyGenericActor {
 
-  val appContext: ApplicationContext = new ClassPathXmlApplicationContext()(appContextPath)
+  val appContext: ApplicationContext = new ClassPathXmlApplicationContext(appContextPath)
   val factory: AutowireCapableBeanFactory = appContext.getAutowireCapableBeanFactory
 
   override def onStart(): Unit = {
     super.onStart()
-    factory.autowireBeanProperties(this, AutowireCapableBeanFactory.AUTOWIRE_BY_NAME, true)
+    factory.autowireBeanProperties(this, AutowireCapableBeanFactory.AUTOWIRE_BY_TYPE, true)
   }
 }

--- a/fey-core/src/main/scala/org/apache/iota/fey/FeyGenericSpringActor.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/FeyGenericSpringActor.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iota.fey
+
+import akka.actor.ActorRef
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory
+
+import scala.concurrent.duration._
+import org.springframework.context.ApplicationContext
+import org.springframework.context.support.ClassPathXmlApplicationContext
+
+abstract class FeyGenericSpringActor(override val params: Map[String,String] = Map.empty,
+                                    override val backoff: FiniteDuration = 1.minutes,
+                                    override val connectTo: Map[String,ActorRef] = Map.empty,
+                                    override val schedulerTimeInterval: FiniteDuration = 2.seconds,
+                                    override val orchestrationName: String = "",
+                                    override val orchestrationID: String = "",
+                                    override val autoScale: Boolean = false,
+                                    val appContextPath: String = "") extends FeyGenericActor {
+
+  val appContext: ApplicationContext = new ClassPathXmlApplicationContext()(appContextPath)
+  val factory: AutowireCapableBeanFactory = appContext.getAutowireCapableBeanFactory
+
+  override def onStart(): Unit = {
+    super.onStart()
+    factory.autowireBeanProperties(this, AutowireCapableBeanFactory.AUTOWIRE_BY_NAME, true)
+  }
+}

--- a/fey-core/src/main/scala/org/apache/iota/fey/Utils.scala
+++ b/fey-core/src/main/scala/org/apache/iota/fey/Utils.scala
@@ -194,6 +194,7 @@ object JSON_PATH{
   val SOURCE: String = "source"
   val SOURCE_NAME: String = "name"
   val SOURCE_CLASSPATH: String = "classPath"
+  val SOURCE_CONTEXTPATH: String = "contextPath"
   val SOURCE_PARAMS: String = "parameters"
   val ORCHESTRATION_NAME = "name"
   val ORCHESTRATION_TIMESTAMP = "timestamp"

--- a/fey-core/src/test/scala/org/apache/iota/fey/FeyGenericSpringActorSpec.scala
+++ b/fey-core/src/test/scala/org/apache/iota/fey/FeyGenericSpringActorSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iota.fey
+
+import akka.actor.{ActorRef, Props}
+import akka.testkit.{EventFilter, TestActorRef, TestProbe}
+
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
+class FeyGenericSpringActorSpec extends BaseAkkaSpec {
+  val parent = TestProbe("GENERIC-PARENT")
+  val monitor = TestProbe("MONITOR-GENERIC")
+  val connectTB = TestProbe("CONNECT_TO")
+  val genericRef: TestActorRef[FeyGenericSpringActorTest] = TestActorRef[FeyGenericSpringActorTest]( Props(new FeyGenericSpringActorTest(Map.empty, 1.seconds,
+    Map("CONNECTED" -> connectTB.ref),300.milliseconds,"MY-ORCH", "MY-ORCH", false, "classpath:FeyApplicationContext.xml"){
+    override private[fey] val monitoring_actor = monitor.ref
+  }),parent.ref, "GENERIC-TEST")
+  var genericState:FeyGenericSpringActorTest = genericRef.underlyingActor
+  val path = genericRef.path.toString
+  var latestBackoff: Long = 0
+
+  "Creating a GenericSpringActor using the TestContext" should {
+    "result in a loaded context" in {
+      genericState.contextStarted should be(true)
+    }
+    "result in a new bean factory" in {
+      genericState.factoryStarted should be(true)
+    }
+  }
+}

--- a/fey-core/src/test/scala/org/apache/iota/fey/FeyGenericSpringActorTest.scala
+++ b/fey-core/src/test/scala/org/apache/iota/fey/FeyGenericSpringActorTest.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iota.fey
+
+import akka.actor.ActorRef
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory
+import org.springframework.context.ApplicationContext
+
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.duration.FiniteDuration
+
+class FeyGenericSpringActorTest(override val params: Map[String,String] = Map.empty,
+                                override val backoff: FiniteDuration = 1.minutes,
+                                override val connectTo: Map[String,ActorRef] = Map.empty,
+                                override val schedulerTimeInterval: FiniteDuration = 2.seconds,
+                                override val orchestrationName: String = "",
+                                override val orchestrationID: String = "",
+                                override val autoScale: Boolean = false,
+                                override val appContextPath: String) extends FeyGenericSpringActor(params, backoff, connectTo, schedulerTimeInterval, orchestrationName, orchestrationID, autoScale, appContextPath) {
+
+  var contextStarted = false
+  var factoryStarted = false
+  var received = false
+
+  override def onStart(): Unit = {
+    if (appContext.isInstanceOf[ApplicationContext]) contextStarted = true
+    if (factory.isInstanceOf[AutowireCapableBeanFactory]) factoryStarted = true
+  }
+
+  override def processMessage[T](message: T, sender: ActorRef): Unit = {
+  }
+
+  override def execute(): Unit = {
+  }
+
+  override def customReceive: Receive = {
+    case "SPRING_TEST" => received = true
+  }
+
+  override def onStop(): Unit = {
+  }
+
+  override def onRestart(reason: Throwable): Unit = {
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -23,7 +23,7 @@ object ModuleDependencies {
 
   import Dependencies._
   val FeyDependencies           = compile(akka_actor,typesafe_config,playJson,slf4j,log4jbind,sprayCan,
-                                            sprayRouting,jsonValidator,javaFilter,codec,apacheIO,playNetty) ++ test(akka_testkit, scala_test)
+                                            sprayRouting,jsonValidator,javaFilter,codec,apacheIO,playNetty,springframework) ++ test(akka_testkit, scala_test)
   val StreamDependencies        = provided(akka_actor, fey)
   val ZMQDependencies           = provided(akka_actor,  fey) ++ compile(zmq)
   val VirtualSensorDependencies = provided(akka_actor,  fey) ++ compile(math3)

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -61,6 +61,8 @@ object BuildSettings {
       case PathList("org", "slf4j", xs @ _*)  => MergeStrategy.last
       case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.last
       case PathList("scala", "xml", xs @ _*)         => MergeStrategy.last
+      case PathList("META-INF", "spring.tooling") => MergeStrategy.last
+      case PathList("org", "aopalliance", xs @ _*) => MergeStrategy.last
       case x =>
         val oldStrategy = (assemblyMergeStrategy in assembly).value
         oldStrategy(x)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,6 +37,8 @@ object Dependencies {
   val playNetty       = "com.typesafe.play"   %% "play-netty-server"          % "2.5.8"
   val jsonValidator   = "com.eclipsesource"   %% "play-json-schema-validator" % "0.7.0"
 
+  val springframework = "org.springframework" % "spring-context"              % "4.3.9.RELEASE" exclude("commons-logging","commons-logging")
+
   //Logger
   val slf4j           = "com.typesafe.akka"   %% "akka-slf4j"                 % "2.4.10"
   val log4jbind       = "ch.qos.logback"      %  "logback-classic"            % "1.1.7"


### PR DESCRIPTION
Our proposed implementation consists of creating a class that extends the original FeyGenericActor (named FeyGenericSpringActor), which allows for one more argument to be passed within its constructor, which is a String containing a path for the XML file containing that actor's Spring context, which can be an absolute or relative filesystem path (relative to the current VM working directory) or obtained from the classpath (by specifying a "classpath:" prefix); other protocols and prefixes may be supported by the Spring framework. The new actor class has two attributes: an ApplicationContext and its AutowireCapableBeanFactory, which will allow us to instantiate the beans specified in the actor's context.

Other modifications to the fey engine core include the necessary changes related to parsing the orchestration JSON: adding an entry for the actor context's file path on the JSON validator and parser method, along with a conditional check to see if a path to the actor's context was specified in the JSON, so that fey will instantiate a FeyGenericSpringActor instead of a FeyGenericActor.

Lastly, we've created a FeyApplicationContext.xml, which should be the parent context to all actor contexts created, and will contain useful universal declarations. For now, all it does is enable annotation usage in all Spring actors.